### PR TITLE
Feat/create other types than mangas

### DIFF
--- a/app/api/contents/route.ts
+++ b/app/api/contents/route.ts
@@ -11,6 +11,7 @@ import { unstable_expireTag as expireTag } from "next/cache";
 import { cacheTagEnum } from "@/lib/cachedRequests/cacheTagEnum";
 import { deleteOldFile } from "@/lib/actions/contents.actions";
 import { contentTypes } from "@/prisma/constant";
+import { getTypeIdFromKey, getTypeIdFromStr } from "@/lib/contentTypes.utils";
 
 // Types
 type ApiResponse<T = any> = {
@@ -79,7 +80,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { image, ...contentData } = parsedData.data;
+    const { image, type, ...contentData } = parsedData.data;
     const isImageFile = image instanceof File;
     const imageName = isImageFile ? generateImageName(image) : image;
 
@@ -93,7 +94,7 @@ export async function POST(request: NextRequest) {
         image: imageName,
         userId,
         isSelfHosted: isImageFile,
-        typeId: contentTypes.manga.id,
+        typeId: getTypeIdFromStr(type),
       },
     });
 
@@ -160,7 +161,7 @@ export async function PUT(request: NextRequest) {
       );
     }
 
-    const { image, ...updateData } = parsedData.data;
+    const { image, type, ...updateData } = parsedData.data;
     let imageName;
     let isImageFile = false;
 

--- a/components/forms/contentForm/AddContentForm.tsx
+++ b/components/forms/contentForm/AddContentForm.tsx
@@ -17,11 +17,13 @@ import { Textarea } from "@/components/ui/textarea";
 import useFetch from "@/lib/hooks/useFetch";
 import { contentSchemaClient } from "@/lib/schemas/contents/contentSchemaClient";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Select } from "@radix-ui/react-select";
 import { useRouter } from "next/navigation";
 import { FormEvent } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import * as z from "zod";
+import { SelectType } from "./items/SelectType";
 
 const AddContentForm = () => {
   const { refetch, isLoading } = useFetch();
@@ -149,6 +151,21 @@ const AddContentForm = () => {
                   type="number"
                   {...field}
                 />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* type */}
+        <FormField
+          control={form.control}
+          name="type"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Chapter</FormLabel>
+              <FormControl>
+                <SelectType {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/components/forms/contentForm/AddContentForm.tsx
+++ b/components/forms/contentForm/AddContentForm.tsx
@@ -165,7 +165,7 @@ const AddContentForm = () => {
             <FormItem>
               <FormLabel>Chapter</FormLabel>
               <FormControl>
-                <SelectType {...field} />
+                <SelectType field={field} />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/components/forms/contentForm/items/SelectType.tsx
+++ b/components/forms/contentForm/items/SelectType.tsx
@@ -1,0 +1,30 @@
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectGroup,
+  SelectLabel,
+  SelectItem,
+} from "@/components/ui/select";
+import React from "react";
+
+export const SelectType = (
+  props: Omit<React.ComponentProps<typeof Select>, "children">
+) => (
+  <Select {...props}>
+    <SelectTrigger className="w-[180px]">
+      <SelectValue placeholder="Select a fruit" />
+    </SelectTrigger>
+    <SelectContent>
+      <SelectGroup>
+        <SelectLabel>Fruits</SelectLabel>
+        <SelectItem value="apple">Apple</SelectItem>
+        <SelectItem value="banana">Banana</SelectItem>
+        <SelectItem value="blueberry">Blueberry</SelectItem>
+        <SelectItem value="grapes">Grapes</SelectItem>
+        <SelectItem value="pineapple">Pineapple</SelectItem>
+      </SelectGroup>
+    </SelectContent>
+  </Select>
+);

--- a/components/forms/contentForm/items/SelectType.tsx
+++ b/components/forms/contentForm/items/SelectType.tsx
@@ -1,3 +1,10 @@
+"use client";
+import {
+  FormControl,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import {
   Select,
   SelectTrigger,
@@ -7,24 +14,43 @@ import {
   SelectLabel,
   SelectItem,
 } from "@/components/ui/select";
+import { contentTypes, contentTypesKeys } from "@/prisma/constant";
 import React from "react";
+import { ControllerRenderProps } from "react-hook-form";
 
-export const SelectType = (
-  props: Omit<React.ComponentProps<typeof Select>, "children">
-) => (
-  <Select {...props}>
-    <SelectTrigger className="w-[180px]">
-      <SelectValue placeholder="Select a fruit" />
-    </SelectTrigger>
-    <SelectContent>
-      <SelectGroup>
-        <SelectLabel>Fruits</SelectLabel>
-        <SelectItem value="apple">Apple</SelectItem>
-        <SelectItem value="banana">Banana</SelectItem>
-        <SelectItem value="blueberry">Blueberry</SelectItem>
-        <SelectItem value="grapes">Grapes</SelectItem>
-        <SelectItem value="pineapple">Pineapple</SelectItem>
-      </SelectGroup>
-    </SelectContent>
-  </Select>
+export const SelectType = ({
+  field,
+}: {
+  field: ControllerRenderProps<
+    {
+      title: string;
+      image: string | FileList;
+      type: string;
+      readerUrl: string;
+      chapter: number;
+      description?: string | null | undefined;
+    },
+    "type"
+  >;
+}) => (
+  <FormItem>
+    <FormLabel>Email</FormLabel>
+    <Select onValueChange={field.onChange} defaultValue={field.value}>
+      <FormControl>
+        <SelectTrigger className="w-[180px]">
+          <SelectValue placeholder="Choisis ton contenu" />
+        </SelectTrigger>
+      </FormControl>
+      <SelectContent>
+        <SelectGroup>
+          {contentTypesKeys.map((key) => (
+            <SelectItem value={key} key={key}>
+              {contentTypes[key].name}
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+    <FormMessage />
+  </FormItem>
 );

--- a/lib/actions/external/mangadex.sanityze.ts
+++ b/lib/actions/external/mangadex.sanityze.ts
@@ -24,6 +24,7 @@ export const sanityzeMangadexResponse = (
       chapter: 0,
       mangadexId: manga.id,
       isSelfHosted: false,
+      type: "manga",
     };
   });
 };

--- a/lib/contentTypes.utils.ts
+++ b/lib/contentTypes.utils.ts
@@ -9,6 +9,10 @@ export const allContentTypesIdsAvailable = contentTypesValues.map(
   (type) => type.id
 );
 export const getTypeIdFromKey = (key: ContentTypeKey) => contentTypes[key].id;
+export const getTypeIdFromStr = (str: string) => {
+  const key = contentTypesKeys.find((key) => key === str) ?? "autre";
+  return getTypeIdFromKey(key);
+};
 export const getKeyFromId = (id: number) =>
   contentTypesKeys.find((key) => contentTypes[key].id === id);
 export const getManyKeysFromStr = (ids: string) => {

--- a/lib/schemas/contents/contentSchema.ts
+++ b/lib/schemas/contents/contentSchema.ts
@@ -19,7 +19,9 @@ export const contentWithoutImage = z.object({
     .number({ message: "Doit être un nombre valide" })
     .describe("Chapitre, par exemple le dernier chapitre lu"),
   type: z
-    .enum([...contentTypesKeys] as [string, ...string[]])
+    .enum([...contentTypesKeys] as [string, ...string[]], {
+      message: "Doit être un type de contenu valide",
+    })
     .describe('Type de contenu (ex: "manga")'),
 });
 

--- a/lib/schemas/contents/contentSchema.ts
+++ b/lib/schemas/contents/contentSchema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { MAX_FILE_SIZE } from "./constant";
+import { contentTypesKeys } from "@/prisma/constant";
 
 export const contentWithoutImage = z.object({
   title: z
@@ -17,6 +18,9 @@ export const contentWithoutImage = z.object({
   chapter: z.coerce
     .number({ message: "Doit être un nombre valide" })
     .describe("Chapitre, par exemple le dernier chapitre lu"),
+  type: z
+    .enum([...contentTypesKeys] as [string, ...string[]])
+    .describe('Type de contenu (ex: "manga")'),
 });
 
 export const contentSchemaInputServer = contentWithoutImage.extend({

--- a/lib/schemas/contents/contentSchemaClient.ts
+++ b/lib/schemas/contents/contentSchemaClient.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { contentWithoutImage } from "./contentSchema";
 import { MAX_FILE_SIZE } from "./constant";
+import { contentTypesKeys } from "@/prisma/constant";
 
 export const contentSchemaClient = contentWithoutImage.extend({
   image: z.union([


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the content management system, focusing on content type handling, form updates, and utility functions. The most important changes include adding a new content type selection in forms, updating the API routes to handle content types dynamically, and introducing utility functions for content type management.

Enhancements to content type handling:

* [`app/api/contents/route.ts`](diffhunk://#diff-aad081ed69a4b98de75f16a66a5fe96df32195455528279345755dbf7cba10f9R14): Added the `getTypeIdFromKey` and `getTypeIdFromStr` utility functions to manage content types dynamically and updated the `POST` and `PUT` methods to include the `type` field in the request data. [[1]](diffhunk://#diff-aad081ed69a4b98de75f16a66a5fe96df32195455528279345755dbf7cba10f9R14) [[2]](diffhunk://#diff-aad081ed69a4b98de75f16a66a5fe96df32195455528279345755dbf7cba10f9L82-R83) [[3]](diffhunk://#diff-aad081ed69a4b98de75f16a66a5fe96df32195455528279345755dbf7cba10f9L96-R97) [[4]](diffhunk://#diff-aad081ed69a4b98de75f16a66a5fe96df32195455528279345755dbf7cba10f9L163-R164)

Form updates:

* [`components/forms/contentForm/AddContentForm.tsx`](diffhunk://#diff-865daf803331761c454056783a4c8f0f3da848891987e922e227472da2aaa500R20-R26): Integrated a new `SelectType` component to allow users to select content types when adding content. [[1]](diffhunk://#diff-865daf803331761c454056783a4c8f0f3da848891987e922e227472da2aaa500R20-R26) [[2]](diffhunk://#diff-865daf803331761c454056783a4c8f0f3da848891987e922e227472da2aaa500R160-R174)
* [`components/forms/contentForm/items/SelectType.tsx`](diffhunk://#diff-6d5f253aaab58df843f1d3345c8948c3756430ea701553fd0354a7f0d6521c6bR1-R56): Created the `SelectType` component to provide a dropdown for selecting content types, using the `Select` component from `@radix-ui/react-select`.

Utility functions for content type management:

* [`lib/contentTypes.utils.ts`](diffhunk://#diff-d83c917ab7536af1d26af04e2eaae27dd6efd3231b02c2c32684e7c519a5c5aaR12-R15): Added the `getTypeIdFromStr` function to convert a content type string to its corresponding ID.

Schema updates:

* `lib/schemas/contents/contentSchema.ts` and `lib/schemas/contents/contentSchemaClient.ts`: Updated the content schema to include a `type` field, ensuring that the type is validated against the available content types. [[1]](diffhunk://#diff-ecfd3c849138ccb67db9389d42d61e7f00961e418779cbcca89526ede2c07374R3) [[2]](diffhunk://#diff-ecfd3c849138ccb67db9389d42d61e7f00961e418779cbcca89526ede2c07374R21-R25) [[3]](diffhunk://#diff-ed9db9a4ff4426a016b10750b0d4900fc968b0d5283cb7278e4acf671520d938R4)

Other changes:

* [`lib/actions/external/mangadex.sanityze.ts`](diffhunk://#diff-183fa811480ffb6c89fe500b44702406f501c6760c42d15725c4463d8ba264e6R27): Updated the `sanityzeMangadexResponse` function to include the `type` field in the response data.