### PR TITLE
feat: refactor contentTypes utility functions for improved organizati…

### DIFF
--- a/__test__/contentTypes.test.ts
+++ b/__test__/contentTypes.test.ts
@@ -1,9 +1,4 @@
-import {
-  allContentTypesIdsAvailable,
-  getTypeIdFromKey,
-  getKeyFromId,
-  getManyKeysFromStr,
-} from "@/lib/contentTypes.utils";
+import contentypesUtilities from "@/lib/contentTypes.utils";
 import {
   contentTypesValues,
   ContentTypeKey,
@@ -14,26 +9,32 @@ import { describe, expect, it } from "bun:test";
 describe("contentTypes.utils", () => {
   it("should return all content type ids available", () => {
     const expectedIds = contentTypesValues.map((type) => type.id);
-    expect(allContentTypesIdsAvailable).toEqual(expectedIds);
+    expect(contentypesUtilities.allContentTypesIdsAvailable).toEqual(
+      expectedIds
+    );
   });
 
   it("should return type id from key", () => {
     const key: ContentTypeKey = "manga";
     const expectedId = contentTypes[key].id;
-    expect(getTypeIdFromKey(key)).toBe(expectedId);
+    expect(contentypesUtilities.getTypeIdFromKey(key)).toBe(expectedId);
   });
 
   it("should return key from id", () => {
     const id = 1;
-    expect(getKeyFromId(id)).toBe("manga");
+    expect(contentypesUtilities.getKeyFromId(id)).toBe("manga");
   });
 
   it("should return many keys from ids string", () => {
     const ids = "1,2,3";
-    expect(getManyKeysFromStr(ids)).toEqual(["manga", "film", "serie"]);
+    expect(contentypesUtilities.getManyKeysFromStr(ids)).toEqual([
+      "manga",
+      "film",
+      "serie",
+    ]);
   });
 
   it("should return void array when ids string is empty", () => {
-    expect(getManyKeysFromStr("")).toEqual([]);
+    expect(contentypesUtilities.getManyKeysFromStr("")).toEqual([]);
   });
 });

--- a/app/api/contents/route.ts
+++ b/app/api/contents/route.ts
@@ -10,8 +10,7 @@ import { webdav } from "@/lib/webdav";
 import { unstable_expireTag as expireTag } from "next/cache";
 import { cacheTagEnum } from "@/lib/cachedRequests/cacheTagEnum";
 import { deleteOldFile } from "@/lib/actions/contents.actions";
-import { contentTypes } from "@/prisma/constant";
-import { getTypeIdFromKey, getTypeIdFromStr } from "@/lib/contentTypes.utils";
+import contentypesUtilities from "@/lib/contentTypes.utils";
 
 // Types
 type ApiResponse<T = any> = {
@@ -94,7 +93,7 @@ export async function POST(request: NextRequest) {
         image: imageName,
         userId,
         isSelfHosted: isImageFile,
-        typeId: getTypeIdFromStr(type),
+        typeId: contentypesUtilities.getTypeIdFromStr(type),
       },
     });
 

--- a/components/pages/home/Content/ContentTypeTabs.tsx
+++ b/components/pages/home/Content/ContentTypeTabs.tsx
@@ -1,23 +1,24 @@
 "use client";
-import { Tabs } from "@/components/ui/tabs";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import contentypesUtilities from "@/lib/contentTypes.utils";
+import useCustomSearchParams from "@/lib/hooks/useCustomSearchParams";
 import {
   ContentTypeKey,
   contentTypes,
   contentTypesKeys,
 } from "@/prisma/constant";
 import { PropsWithChildren } from "react";
-import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { toast } from "sonner";
-import useCustomSearchParams from "@/lib/hooks/useCustomSearchParams";
-import { getManyKeysFromStr } from "@/lib/contentTypes.utils";
 export function ContentTypesToggleGroups({
   children,
   currentTab,
 }: PropsWithChildren<{
   currentTab: ContentTypeKey;
 }>) {
-  const { pushQuery, removeQuery, getQuery } = useCustomSearchParams();
-  const types = getManyKeysFromStr(getQuery("types") || "");
+  const { pushQuery, getQuery } = useCustomSearchParams();
+  const types = contentypesUtilities.getManyKeysFromStr(
+    getQuery("types") || ""
+  );
   const handleValueChange = (values: ContentTypeKey[]) => {
     const okContentTypesKeys = values.filter((key) =>
       contentTypesKeys.includes(key)

--- a/lib/contentTypes.utils.ts
+++ b/lib/contentTypes.utils.ts
@@ -5,20 +5,18 @@ import {
   contentTypesKeys,
 } from "@/prisma/constant";
 
-export const allContentTypesIdsAvailable = contentTypesValues.map(
-  (type) => type.id
-);
-export const getTypeIdFromKey = (key: ContentTypeKey) => contentTypes[key].id;
-export const getTypeIdFromStr = (str: string) => {
+const allAvailableTypesIds = contentTypesValues.map((type) => type.id);
+const getTypeIdFromKey = (key: ContentTypeKey) => contentTypes[key].id;
+const getTypeIdFromStr = (str: string) => {
   const key = contentTypesKeys.find((key) => key === str) ?? "autre";
   return getTypeIdFromKey(key);
 };
-export const getKeyFromId = (id: number) =>
+const getKeyFromId = (id: number) =>
   contentTypesKeys.find((key) => contentTypes[key].id === id);
-export const getManyKeysFromStr = (ids: string) => {
+const getManyKeysFromStr = (ids: string) => {
   return ids?.split(",").reduce((acc, id) => {
     const idNumber = parseInt(id);
-    if (!isNaN(idNumber) && allContentTypesIdsAvailable.includes(idNumber)) {
+    if (!isNaN(idNumber) && allAvailableTypesIds.includes(idNumber)) {
       const key = getKeyFromId(idNumber);
       if (key) {
         acc.push(key);
@@ -27,3 +25,11 @@ export const getManyKeysFromStr = (ids: string) => {
     return acc;
   }, [] as ContentTypeKey[]);
 };
+const contentTypesUtilities = {
+  getTypeIdFromKey,
+  getTypeIdFromStr,
+  getKeyFromId,
+  getManyKeysFromStr,
+  allContentTypesIdsAvailable: allAvailableTypesIds,
+};
+export default contentTypesUtilities;


### PR DESCRIPTION
This pull request refactors the import and usage of utility functions from `contentTypes.utils` across various files. The key changes include consolidating these functions into a single `contentTypesUtilities` object and updating all relevant imports and references accordingly.

Refactoring utility imports:

* [`__test__/contentTypes.test.ts`](diffhunk://#diff-112497f165abbe9f529757197dd1b1051eee009aba0808aff03cf61c258b6ff7L1-R1): Updated the import statement to use `contentTypesUtilities` and modified all references to the utility functions to use this new object. [[1]](diffhunk://#diff-112497f165abbe9f529757197dd1b1051eee009aba0808aff03cf61c258b6ff7L1-R1) [[2]](diffhunk://#diff-112497f165abbe9f529757197dd1b1051eee009aba0808aff03cf61c258b6ff7L17-R38)
* [`app/api/contents/route.ts`](diffhunk://#diff-aad081ed69a4b98de75f16a66a5fe96df32195455528279345755dbf7cba10f9L13-R13): Changed the import of utility functions to use `contentTypesUtilities` and updated the function calls accordingly. [[1]](diffhunk://#diff-aad081ed69a4b98de75f16a66a5fe96df32195455528279345755dbf7cba10f9L13-R13) [[2]](diffhunk://#diff-aad081ed69a4b98de75f16a66a5fe96df32195455528279345755dbf7cba10f9L97-R96)
* [`components/pages/home/Content/ContentTypeTabs.tsx`](diffhunk://#diff-b672ab730cfb4782bc73ea90f8049dfcd3e8d55be9845d8be986ae6c77298eadL2-R21): Modified the import statement to use `contentTypesUtilities` and updated the relevant function call.
* [`lib/contentTypes.utils.ts`](diffhunk://#diff-d83c917ab7536af1d26af04e2eaae27dd6efd3231b02c2c32684e7c519a5c5aaL8-R19): Consolidated the utility functions into a single `contentTypesUtilities` object and updated the export statement. [[1]](diffhunk://#diff-d83c917ab7536af1d26af04e2eaae27dd6efd3231b02c2c32684e7c519a5c5aaL8-R19) [[2]](diffhunk://#diff-d83c917ab7536af1d26af04e2eaae27dd6efd3231b02c2c32684e7c519a5c5aaR28-R35)…on and usage