### PR TITLE
Feat/addcontent optionals datas

### DIFF
--- a/components/forms/contentForm/AddContentForm.tsx
+++ b/components/forms/contentForm/AddContentForm.tsx
@@ -17,13 +17,12 @@ import { Textarea } from "@/components/ui/textarea";
 import useFetch from "@/lib/hooks/useFetch";
 import { contentSchemaClient } from "@/lib/schemas/contents/contentSchemaClient";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Select } from "@radix-ui/react-select";
 import { useRouter } from "next/navigation";
 import { FormEvent } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import * as z from "zod";
-import { SelectType } from "./items/SelectType";
+import { SelectType } from "@/components/forms/contentForm/items/SelectType";
 
 const AddContentForm = () => {
   const { refetch, isLoading } = useFetch();
@@ -128,7 +127,11 @@ const AddContentForm = () => {
             <FormItem>
               <FormLabel>Reader URL</FormLabel>
               <FormControl>
-                <Input placeholder="https://example.com" {...field} />
+                <Input
+                  placeholder="https://example.com"
+                  {...field}
+                  value={field.value ?? ""}
+                />
               </FormControl>
               <FormDescription>Url du lecteur en ligne</FormDescription>
               <FormMessage />
@@ -161,15 +164,7 @@ const AddContentForm = () => {
         <FormField
           control={form.control}
           name="type"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>Chapter</FormLabel>
-              <FormControl>
-                <SelectType field={field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
+          render={({ field }) => <SelectType field={field} />}
         />
 
         <Button type="submit" disabled={isLoading}>

--- a/components/forms/contentForm/AddContentMagicForm.tsx
+++ b/components/forms/contentForm/AddContentMagicForm.tsx
@@ -44,7 +44,7 @@ const AddContentMagicForm = () => {
       Object.entries(selectedContent).forEach(([key, value]) => {
         const okValue = value?.toString();
 
-        formdata.append(key, okValue);
+        if (okValue) formdata.append(key, okValue);
       });
       const result = await refetch("/api/contents", {
         method: "POST",

--- a/components/forms/contentForm/AddContentMagicForm.tsx
+++ b/components/forms/contentForm/AddContentMagicForm.tsx
@@ -104,7 +104,8 @@ const AddContentMagicForm = () => {
               {...{
                 ...selectedItem,
                 isSelfHosted: false,
-                description: selectedItem.description ?? "",
+                description: selectedItem.description,
+                readerUrl: selectedItem.readerUrl,
               }}
             ></ContentCardProvider>
             <ButtonAction action={handleClick}>Ajouter</ButtonAction>

--- a/components/forms/contentForm/ContentCardEditedForm.tsx
+++ b/components/forms/contentForm/ContentCardEditedForm.tsx
@@ -127,7 +127,7 @@ const ContentCardEditedForm = (
                 <FormControl>
                   <Textarea
                     {...field}
-                    value={field.value ?? ""}
+                    value={field.value || ""}
                     placeholder={
                       friendlyNames[
                         field.name as keyof ContentSchemaClientPartial
@@ -151,6 +151,7 @@ const ContentCardEditedForm = (
                 <FormControl>
                   <Textarea
                     {...field}
+                    value={field.value || ""}
                     placeholder={
                       friendlyNames[
                         field.name as keyof ContentSchemaClientPartial

--- a/components/forms/contentForm/items/SelectType.tsx
+++ b/components/forms/contentForm/items/SelectType.tsx
@@ -14,27 +14,18 @@ import {
   SelectLabel,
   SelectItem,
 } from "@/components/ui/select";
+import { contentSchemaClient } from "@/lib/schemas/contents/contentSchemaClient";
 import { contentTypes, contentTypesKeys } from "@/prisma/constant";
 import React from "react";
 import { ControllerRenderProps } from "react-hook-form";
-
+import { z } from "zod";
 export const SelectType = ({
   field,
 }: {
-  field: ControllerRenderProps<
-    {
-      title: string;
-      image: string | FileList;
-      type: string;
-      readerUrl: string;
-      chapter: number;
-      description?: string | null | undefined;
-    },
-    "type"
-  >;
+  field: ControllerRenderProps<z.infer<typeof contentSchemaClient>, "type">;
 }) => (
   <FormItem>
-    <FormLabel>Email</FormLabel>
+    <FormLabel>Type</FormLabel>
     <Select onValueChange={field.onChange} defaultValue={field.value}>
       <FormControl>
         <SelectTrigger className="w-[180px]">

--- a/lib/cachedRequests/content/getPersonnalContents.ts
+++ b/lib/cachedRequests/content/getPersonnalContents.ts
@@ -6,6 +6,7 @@ import {
   unstable_cacheTag as cacheTag,
 } from "next/cache";
 import { cacheTagEnum } from "../cacheTagEnum";
+import { Optional } from "@prisma/client/runtime/library";
 
 type Props = {
   userId: string;
@@ -47,4 +48,15 @@ export const getPersonnalContents = async ({
 export type PersonnalContents = Awaited<
   ReturnType<typeof getPersonnalContents>
 >;
-export type PersonnalContent = PersonnalContents[number];
+
+type PersonnalContentPrimitive = PersonnalContents[number];
+
+type NullableAlsoOptional<T> = T extends null
+  ? undefined | T
+  : T extends (infer U)[]
+    ? NullableAlsoOptional<U>[]
+    : T extends Record<string, unknown>
+      ? { [K in keyof T]: NullableAlsoOptional<T[K]> }
+      : T;
+
+export type PersonnalContent = NullableAlsoOptional<PersonnalContents[number]>;

--- a/lib/schemas/contents/contentSchema.ts
+++ b/lib/schemas/contents/contentSchema.ts
@@ -14,7 +14,8 @@ export const contentWithoutImage = z.object({
     .describe(
       "Url du lecteur en ligne ( https://exemple.com/lecture-enligne/one-piece )"
     )
-    .nullable(),
+    .nullable()
+    .optional(),
 
   chapter: z.coerce
     .number({ message: "Doit être un nombre valide" })

--- a/lib/schemas/contents/contentSchema.ts
+++ b/lib/schemas/contents/contentSchema.ts
@@ -13,7 +13,8 @@ export const contentWithoutImage = z.object({
     .url({ message: "Doit être une url valide ( https://exemple.com/ )" })
     .describe(
       "Url du lecteur en ligne ( https://exemple.com/lecture-enligne/one-piece )"
-    ),
+    )
+    .nullable(),
 
   chapter: z.coerce
     .number({ message: "Doit être un nombre valide" })

--- a/lib/schemas/contents/contentSchemaClient.ts
+++ b/lib/schemas/contents/contentSchemaClient.ts
@@ -4,24 +4,29 @@ import { MAX_FILE_SIZE } from "./constant";
 import { contentTypesKeys } from "@/prisma/constant";
 
 export const contentSchemaClient = contentWithoutImage.extend({
-  image: z.union([
-    z
-      .string({ message: "Doit être une image valide (ou url si selectionné)" })
-      .url({ message: "Doit être une url valide" })
-      .describe(
-        "Url de l'image de couverture ( https://exemple.com/image.jpg )"
-      ),
-    z
-      .instanceof(FileList)
-      .refine(
-        (file) => file[0].type.startsWith("image/"),
-        "Le fichier doit être une image"
-      )
-      .refine(
-        (file) => file[0].size <= MAX_FILE_SIZE,
-        `L'image doit faire maximum ${MAX_FILE_SIZE / (1024 * 1024)} MB`
-      ),
-  ]),
+  image: z
+    .union([
+      z
+        .string({
+          message: "Doit être une image valide (ou url si selectionné)",
+        })
+        .url({ message: "Doit être une url valide" })
+        .describe(
+          "Url de l'image de couverture ( https://exemple.com/image.jpg )"
+        ),
+      z
+        .instanceof(FileList)
+        .refine(
+          (file) => file[0].type.startsWith("image/"),
+          "Le fichier doit être une image"
+        )
+        .refine(
+          (file) => file[0].size <= MAX_FILE_SIZE,
+          `L'image doit faire maximum ${MAX_FILE_SIZE / (1024 * 1024)} MB`
+        ),
+    ])
+    .optional()
+    .nullable(),
 });
 
 export const contentSchemaClientPartial = contentSchemaClient.partial();


### PR DESCRIPTION
This pull request includes various changes to the content forms and schemas to improve form handling and validation. The changes mainly focus on updating imports, enhancing form field handling, and making certain fields optional and nullable.

### Form Handling Improvements:
* Updated import paths for `SelectType` in `AddContentForm.tsx` to use the correct relative path.
* Improved handling of the `Input` component's value in `AddContentForm.tsx` by ensuring it defaults to an empty string if `field.value` is `null` or `undefined`.
* Simplified the rendering of the `SelectType` component within `FormField` in `AddContentForm.tsx`.
* Added a check to ensure only non-null values are appended to `formdata` in `AddContentMagicForm.tsx`.
* Updated `Textarea` components in `ContentCardEditedForm.tsx` to use `||` instead of `??` for default value handling. [[1]](diffhunk://#diff-61f56e2235bae5379351726dc85eddc9acfc32a1f9aff20d9fc2e01ea73c0574L130-R130) [[2]](diffhunk://#diff-61f56e2235bae5379351726dc85eddc9acfc32a1f9aff20d9fc2e01ea73c0574R154)

### Schema and Type Enhancements:
* Included `contentSchemaClient` import in `SelectType.tsx` and updated the type definition for the `field` prop to use `z.infer`.
* Added `Optional` import in `getPersonnalContents.ts` and introduced `NullableAlsoOptional` type to handle nullable and optional fields. [[1]](diffhunk://#diff-28d7fac81edb4a1dc1ab71463ee3ef15bb2008e8d8b1f911e47e33a85bc215f1R9) [[2]](diffhunk://#diff-28d7fac81edb4a1dc1ab71463ee3ef15bb2008e8d8b1f911e47e33a85bc215f1L50-R62)
* Made `readerUrl` field nullable and optional in `contentSchema.ts`.
* Updated `contentSchemaClient` to make the `image` field optional and nullable. [[1]](diffhunk://#diff-ed9db9a4ff4426a016b10750b0d4900fc968b0d5283cb7278e4acf671520d938L7-R12) [[2]](diffhunk://#diff-ed9db9a4ff4426a016b10750b0d4900fc968b0d5283cb7278e4acf671520d938L24-R29)